### PR TITLE
Fixes #2: Prevent Duplicate Usernames

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,39 +1,65 @@
-#include<bits/stdc++.h>
+// #include<bits/stdc++.h>
 #include <iostream>
 #include "sqlite3.h"
 #include <string>
 using namespace std;
 
-class ComplaintBox {
+class ComplaintBox
+{
 public:
-    ComplaintBox() {
+    ComplaintBox()
+    {
         sqlite3_open("complaints.db", &db);
         createTables();
     }
 
-    ~ComplaintBox() {
+    ~ComplaintBox()
+    {
         sqlite3_close(db);
     }
 
-    void registerUser(bool isAdmin = false) {
+    void registerUser(bool isAdmin = false)
+    {
         string uname, pass;
         cout << "Enter username: ";
         cin >> uname;
+
+        // --To check duplicate Username while Registering--
+
+        string checkSql = "SELECT * FROM users WHERE username='" + uname + "';";
+        bool exists = false;
+
+        sqlite3_exec(db, checkSql.c_str(), [](void *data, int, char **, char **) -> int
+                     {
+            *(bool *)data = true;    // same func as in loginUser
+            return 0; }, &exists, &errMsg);
+        
+        if (exists)
+        {
+            cout << "Username already exists. Please choose a different Username" << endl;
+            return;
+        }
+        
+        // if not exists then continue
         cout << "Enter password: ";
         cin >> pass;
 
         string table = isAdmin ? "adminusers" : "users";
         string sql = "INSERT INTO " + table + " (username, password) VALUES ('" + uname + "', '" + pass + "');";
 
-        if (sqlite3_exec(db, sql.c_str(), 0, 0, &errMsg) != SQLITE_OK) {
+        if (sqlite3_exec(db, sql.c_str(), 0, 0, &errMsg) != SQLITE_OK)
+        {
             cout << "Error: " << errMsg << endl;
             sqlite3_free(errMsg);
-        } else {
+        }
+        else
+        {
             cout << "Registration successful!\n";
         }
     }
 
-    bool loginUser(bool isAdmin = false) {
+    bool loginUser(bool isAdmin = false)
+    {
         string uname, pass;
         cout << "Enter username: ";
         cin >> uname;
@@ -44,21 +70,25 @@ public:
         string sql = "SELECT * FROM " + table + " WHERE username = '" + uname + "' AND password = '" + pass + "';";
         bool success = false;
 
-        sqlite3_exec(db, sql.c_str(), [](void* successPtr, int argc, char** argv, char** colName) -> int {
+        sqlite3_exec(db, sql.c_str(), [](void *successPtr, int argc, char **argv, char **colName) -> int
+                     {
             *(bool*)successPtr = true;
-            return 0;
-        }, &success, &errMsg);
+            return 0; }, &success, &errMsg);
 
-        if (success) {
+        if (success)
+        {
             cout << "Login successful!\n";
             return true;
-        } else {
+        }
+        else
+        {
             cout << "Invalid credentials!\n";
             return false;
         }
     }
 
-    void fileComplaint() {
+    void fileComplaint()
+    {
         string category, subCategory, message;
         cout << "Enter category: ";
         cin.ignore();
@@ -69,19 +99,23 @@ public:
         getline(cin, message);
 
         string sql = "INSERT INTO complaints (category, subCategory, message) VALUES ('" + category + "', '" + subCategory + "', '" + message + "');";
-        if (sqlite3_exec(db, sql.c_str(), 0, 0, &errMsg) != SQLITE_OK) {
+        if (sqlite3_exec(db, sql.c_str(), 0, 0, &errMsg) != SQLITE_OK)
+        {
             cout << "Error: " << errMsg << endl;
             sqlite3_free(errMsg);
-        } else {
+        }
+        else
+        {
             cout << "Complaint filed successfully!\n";
         }
     }
 
 private:
-    sqlite3* db;
-    char* errMsg;
+    sqlite3 *db;
+    char *errMsg;
 
-    void createTables() {
+    void createTables()
+    {
         string sqlUsers = "CREATE TABLE IF NOT EXISTS users (username TEXT PRIMARY KEY, password TEXT);";
         string sqlAdmins = "CREATE TABLE IF NOT EXISTS adminusers (username TEXT PRIMARY KEY, password TEXT);";
         string sqlComplaints = "CREATE TABLE IF NOT EXISTS complaints (category TEXT, subCategory TEXT, message TEXT);";
@@ -92,22 +126,38 @@ private:
     }
 };
 
-int main() {
+int main()
+{
     ComplaintBox cb;
     int choice;
 
-    do {
+    do
+    {
         cout << "\n1. Register User\n2. Register Admin\n3. User Login\n4. Admin Login\n5. File Complaint\n6. Exit\nChoice: ";
         cin >> choice;
 
-        switch (choice) {
-            case 1: cb.registerUser(); break;
-            case 2: cb.registerUser(true); break;
-            case 3: cb.loginUser(); break;
-            case 4: cb.loginUser(true); break;
-            case 5: cb.fileComplaint(); break;
-            case 6: cout << "Exiting..." << endl; break;
-            default: cout << "Invalid choice!\n";
+        switch (choice)
+        {
+        case 1:
+            cb.registerUser();
+            break;
+        case 2:
+            cb.registerUser(true);
+            break;
+        case 3:
+            cb.loginUser();
+            break;
+        case 4:
+            cb.loginUser(true);
+            break;
+        case 5:
+            cb.fileComplaint();
+            break;
+        case 6:
+            cout << "Exiting..." << endl;
+            break;
+        default:
+            cout << "Invalid choice!\n";
         }
     } while (choice != 6);
 


### PR DESCRIPTION
Fixed #2 : Prevent Duplicate Usernames 

Added the checkSql pointer and an flag - "exists" and passed through the sqlite3_exec() function . If username already exists then it prints "Username already exists. Please choose a different Username" else continue. 

Works for both Users and Admins

Additional changes - commented the #include<bits/stdc++.h>

* while working on the issue i used "Format document" in the editor , so a lot of fake additions are shown. will keep in mind not to use that next time *