### PR TITLE
Fixes #6: Add Complaint ID

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -127,14 +127,17 @@ private:
 int main()
 {
     ComplaintBox cb;
-    int choice;
+    string choice;
+    int choiceNum = 0;
 
     do
     {
         cout << "\n1. Register User\n2. Register Admin\n3. User Login\n4. Admin Login\n5. File Complaint\n6. Exit\nChoice: ";
         cin >> choice;
 
-        switch (choice)
+        try {
+            choiceNum = stoi(choice); 
+        switch (choiceNum)
         {
         case 1:
             cb.registerUser();
@@ -157,7 +160,10 @@ int main()
         default:
             cout << "Invalid choice!\n";
         }
-    } while (choice != 6);
+    } catch (exception& e) {  // stoi throw an exception when input is non-numeric string
+        cout << "Invalid input! Please enter a number."<<endl; 
+    }
+}while (choiceNum != 6);
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -104,7 +104,8 @@ public:
         }
         else
         {
-            cout << "Complaint filed successfully!\n";
+            int lastID = sqlite3_last_insert_rowid(db); // get complaintID
+            cout << "Complaint filed successfully! Your Complaint ID is: " << lastID << endl; // print complaintID
         }
     }
 
@@ -116,8 +117,8 @@ private:
     {
         string sqlUsers = "CREATE TABLE IF NOT EXISTS users (username TEXT PRIMARY KEY, password TEXT);";
         string sqlAdmins = "CREATE TABLE IF NOT EXISTS adminusers (username TEXT PRIMARY KEY, password TEXT);";
-        string sqlComplaints = "CREATE TABLE IF NOT EXISTS complaints (category TEXT, subCategory TEXT, message TEXT);";
-
+        string sqlComplaints = "CREATE TABLE IF NOT EXISTS complaints (category TEXT, subCategory TEXT, message TEXT, complaintID INTEGER PRIMARY KEY AUTOINCREMENT);";
+                                                                                                                  // added complaintID with AUTOINCREMENT
         sqlite3_exec(db, sqlUsers.c_str(), 0, 0, &errMsg);
         sqlite3_exec(db, sqlAdmins.c_str(), 0, 0, &errMsg);
         sqlite3_exec(db, sqlComplaints.c_str(), 0, 0, &errMsg);


### PR DESCRIPTION
To create a unique complaint ID for each comlpaint i added another attribute "complaintID" with data type "INTEGER PRIMARY KEY AUTOINCREMENT". So by sqlite in-built feature it creates an unique complaintID each time.

The complaint ID is also printed after submission of each complain.